### PR TITLE
Add setup script and environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Environment configuration for BreakerBot
+# Rename this file to .env and fill in your credentials
+
+# OpenAI API key for ChatGPT features
+OPENAI_API_KEY=
+
+# X.ai API key for Grok commands
+XAI_API_KEY=
+
+# Genius API key for lyrics search
+GENIUS_API_KEY=
+
+# Comma-separated list of WhatsApp numbers (digits only) that can use admin commands
+ADMINS=

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Ensure that you have the following installed on your system:
 git clone https://github.com/GustavoCaruzoGoncalves/BreakerBot.git
 cd BreakerBot
 ```
-#### **2. Install NodeJS Dependencies**  
+#### **2. Run the Setup Script**
 ```sh
-npm install
+./setup.sh
 ```
-#### **3. Run the Bot to authenticate**  
+This script installs the project dependencies, sets up **pm2** and generates a `.env` file.
+Edit `.env` with your API keys and the admin phone numbers before starting the bot.
+#### **3. Run the Bot to authenticate**
 ```sh
 npm start
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Setup script for BreakerBot
+set -e
+
+# Check prerequisites
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required. Please install Node.js >=16 and rerun this script." >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required. Please install npm and rerun this script." >&2
+  exit 1
+fi
+
+# Install pm2 globally if not present
+if ! command -v pm2 >/dev/null 2>&1; then
+  echo "Installing pm2 globally..."
+  npm install -g pm2
+fi
+
+# Install project dependencies
+echo "Installing dependencies..."
+npm install
+
+# Provide environment file
+if [ ! -f .env ]; then
+  if [ ! -f .env.example ]; then
+    cat <<'EOE' > .env.example
+# Copy this file to '.env' and fill in your credentials
+OPENAI_API_KEY=
+XAI_API_KEY=
+GENIUS_API_KEY=
+# Comma-separated list of WhatsApp numbers without spaces
+ADMINS=
+EOE
+  fi
+  cp .env.example .env
+  echo "Created default .env file. Edit it with your API keys and admin numbers." 
+fi
+
+cat <<'EOM'
+Setup complete!
+Run 'npm start' to authenticate the bot.
+After authentication, use 'npm run server' to run BreakerBot with pm2.
+EOM


### PR DESCRIPTION
## Summary
- add setup script for installing dependencies and creating `.env`
- include default `.env.example`
- update README with setup instructions

## Testing
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6852e7085c7c8324b6a9de04bfc928e9